### PR TITLE
Additional objects and fixes

### DIFF
--- a/tik4net.objects/Interface/Interface.cs
+++ b/tik4net.objects/Interface/Interface.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
+﻿namespace tik4net.Objects.Interface {
 namespace tik4net.Objects.Interface
 {
     /// <summary>
@@ -39,7 +35,7 @@ namespace tik4net.Objects.Interface
         /// mtu
         /// </summary>
         [TikProperty("mtu")]
-        public long Mtu { get; set; }
+        public string Mtu { get; set; }
 
         /// <summary>
         /// mac-address

--- a/tik4net.objects/Interface/InterfaceBridge.cs
+++ b/tik4net.objects/Interface/InterfaceBridge.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
+﻿namespace tik4net.Objects.Interface {
 namespace tik4net.Objects.Interface
 {
     /// <summary>
@@ -652,7 +648,7 @@ namespace tik4net.Objects.Interface
         /// mtu: Maximum Transmission Unit
         /// </summary>
         [TikProperty("mtu", DefaultValue = "1500")]
-        public int Mtu { get; set; }
+        public string Mtu { get; set; }
 
         /// <summary>
         /// name: Name of the bridge interface
@@ -713,7 +709,7 @@ namespace tik4net.Objects.Interface
             AutoMac = true;
             ForwardDelay = "00:00:15";
             MaxMessageAge = "00:00:20";
-            Mtu = 1500;
+            Mtu = "1500";
             Priority = "8000";
             ProtocolMode = ProtocolModeModes.Rstp;
             TransmitHoldCount = 6;

--- a/tik4net.objects/Interface/InterfaceEthernet.cs
+++ b/tik4net.objects/Interface/InterfaceEthernet.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
+﻿namespace tik4net.Objects.Interface {
 namespace tik4net.Objects.Interface
 {
     /// <summary>
@@ -76,7 +72,7 @@ namespace tik4net.Objects.Interface
             /// <summary>
             /// no
             /// </summary>
-            [TikEnum("no")]
+            [TikEnum("off")]
             No,
 
             /// <summary>
@@ -242,7 +238,7 @@ namespace tik4net.Objects.Interface
         /// rx-bytes: Total count of received bytes
         /// </summary>
         [TikProperty("rx-bytes", IsReadOnly = true)]
-        public int RxBytes { get; private set; }
+        public long RxBytes { get; private set; }
 
         /// <summary>
         /// rx-fcs-error: Total count of received frames with incorrect checksum
@@ -298,7 +294,7 @@ namespace tik4net.Objects.Interface
         /// switch: ID to which switch chip interface belongs to.
         /// </summary>
         [TikProperty("switch", IsReadOnly = true)]
-        public int Switch { get; private set; }
+        public string Switch { get; private set; }
 
         /// <summary>
         /// tx-1024-1518: Total count of transmitted 1024 to 1518 byte packets
@@ -358,7 +354,7 @@ namespace tik4net.Objects.Interface
         /// tx-bytes: Total count of transmitted bytes
         /// </summary>
         [TikProperty("tx-bytes", IsReadOnly = true)]
-        public int TxBytes { get; private set; }
+        public long TxBytes { get; private set; }
 
         /// <summary>
         /// tx-fcs-error: Total count of transmitted frames with incorrect checksum

--- a/tik4net.objects/Ip/hotspot/HotspotActive.cs
+++ b/tik4net.objects/Ip/hotspot/HotspotActive.cs
@@ -1,0 +1,74 @@
+﻿namespace tik4net.Objects.Ip.Hotspot {
+    /// <summary>
+    /// ip/hotspot/user
+    /// 
+    /// This is the menu, where client's user/password information is actually added, additional configuration options for HotSpot users are configured here as well.
+    /// </summary>
+    [TikEntity("ip/hotspot/active", IsReadOnly = true)]
+    public class HotspotActive {
+
+        /// <summary>
+        /// Server
+        /// </summary>
+        [TikProperty("server", IsReadOnly = true)]
+        public string Server { get; set; }
+
+        /// <summary>
+        /// address: IP address
+        /// </summary>
+        [TikProperty("address", IsReadOnly = true)]
+        public string/*IP*/ Address { get; set; }
+
+        /// <summary>
+        /// The active user's name
+        /// </summary>
+        [TikProperty("user", IsReadOnly = true)]
+        public string UserName { get; set; }
+
+        /// <summary>
+        /// The connection's Mac Address
+        /// </summary>
+        [TikProperty("mac-address", IsReadOnly = true)]
+        public string MacAddress { get; set; }
+
+        /// <summary>
+        /// The connection's Mac Address
+        /// </summary>
+        [TikProperty("login-by", IsReadOnly = true)]
+        public string LoginBy { get; set; }
+
+        /// <summary>
+        /// The amount of time the user has been connected
+        /// </summary>
+        [TikProperty("uptime", IsReadOnly = true)]
+        public /*time*/ string UpTime { get; set; }
+
+        /// <summary>
+        /// The amount of time the connection has been idle
+        /// </summary>
+        [TikProperty("idle-time", IsReadOnly = true)]
+        public /*time*/ string IdleTime { get; set; }
+        /// <summary>
+        /// The amount of time left for the session
+        /// </summary>
+        [TikProperty("session-time-left", IsReadOnly = true)]
+        public /*time*/ string SessionTimeLeft { get; set; }
+        /// <summary>
+        /// The amount of time until the connection will timeout if it remains to be idle
+        /// </summary>
+        [TikProperty("idle-timeout", IsReadOnly = true)]
+        public /*time*/ string IdleTimeout { get; set; }
+
+        /// <summary>
+        /// bytes-in: 
+        /// </summary>
+        [TikProperty("bytes-in", IsReadOnly = true)]
+        public long BytesIn { get; private set; }
+
+        /// <summary>
+        /// bytes-out: 
+        /// </summary>
+        [TikProperty("bytes-out", IsReadOnly = true)]
+        public long BytesOut { get; private set; }
+    }
+}

--- a/tik4net.objects/Ip/hotspot/HotspotUser.cs
+++ b/tik4net.objects/Ip/hotspot/HotspotUser.cs
@@ -1,198 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace tik4net.Objects.Ip.Hotspot
-{
+﻿namespace tik4net.Objects.Ip.Hotspot {
     /// <summary>
     /// ip/hotspot/user
     /// 
     /// This is the menu, where client's user/password information is actually added, additional configuration options for HotSpot users are configured here as well.
     /// </summary>
     [TikEntity("ip/hotspot/user")]
-    public class HotspotUser
-    {
-        #region Submenu classes
-        /// <summary>
-        /// ip/hotspot/user: User profile menu is used for common HotSpot client settings. Profiles are like User groups with the same set of settings, rate-limit, filter chain name, etc. 
-        /// </summary>
-        [TikEntity("ip/hotspot/user/profile")]
-        public class UserProfile
-        {
-            /// <summary>
-            /// .id: primary key of row
-            /// </summary>
-            [TikProperty(".id", IsReadOnly = true, IsMandatory = true)]
-            public string Id { get; private set; }
-
-            /// <summary>
-            /// add-mac-cookie: Allows to add mac cookie for users. Read more&gt;&gt;
-            /// </summary>
-            [TikProperty("add-mac-cookie", DefaultValue = "yes")]
-            public bool AddMacCookie { get; set; }
-
-            /// <summary>
-            /// address-list: Name of the address list in which users IP address will be added. Useful to mark traffic per user groups for queue tree configurations.
-            /// </summary>
-            [TikProperty("address-list")]
-            public string AddressList { get; set; }
-
-            /// <summary>
-            /// address-pool: IP pool name from which the user will get IP. When user has improper network settings configuration on the computer, HotSpot server makes translation and assigns correct IP address from the pool instead of incorrect one
-            /// </summary>
-            [TikProperty("address-pool", DefaultValue = "none")]
-            public string/*string |none*/ AddressPool { get; set; }
-
-            /// <summary>
-            /// advertise: Enable forced advertisement popups. After certain interval specific web-page is being displayed for HotSpot users. Advertisement page might be blocked by browsers popup blockers.
-            /// </summary>
-            [TikProperty("advertise", DefaultValue = "no")]
-            public bool Advertise { get; set; }
-
-            /// <summary>
-            /// advertise-interval: Set of intervals between advertisement popups. After the list is done, the last value is used for all further advertisements, 10 minutes
-            /// </summary>
-            [TikProperty("advertise-interval", DefaultValue = "30m,10m")]
-            public string/*time[,time[,..]]*/ AdvertiseInterval { get; set; }
-
-            /// <summary>
-            /// advertise-timeout: How long advertisement is shown, before blocking network access for HotSpot client. Connection to Internet is not allowed, when advertisement is not shown.
-            /// </summary>
-            [TikProperty("advertise-timeout", DefaultValue = "1m")]
-            public string/*time | immediately | never*/ AdvertiseTimeout { get; set; }
-
-            /// <summary>
-            /// advertise-url: List of URLs that is show for advertisement popups. After the last URL is used, list starts from the begining.
-            /// </summary>
-            [TikProperty("advertise-url")]
-            public string/*string[,string[,..]]*/ AdvertiseUrl { get; set; }
-
-            /// <summary>
-            /// idle-timeout: Maximal period of inactivity for authorized HotSpot clients. Timer is counting, when there is no traffic coming from that client and going through the router, for example computer is switched off. User is logged out, dropped of the host list, the address used by the user is freed, when timeout is reached.
-            /// </summary>
-            [TikProperty("idle-timeout", DefaultValue = "none", UnsetOnDefault = true)]
-            public string/*time | none*/ IdleTimeout { get; set; }
-
-            /// <summary>
-            /// incoming-filter: Name of the firewall chain applied to incoming packets from the users of this profile, jump rule is required from built-in chain (input, forward, output) to chain=hotspot
-            /// </summary>
-            [TikProperty("incoming-filter")]
-            public string IncomingFilter { get; set; }
-
-            /// <summary>
-            /// incoming-packet-mark: Packet mark put on incoming packets from every user of this profile
-            /// </summary>
-            [TikProperty("incoming-packet-mark")]
-            public string IncomingPacketMark { get; set; }
-
-            /// <summary>
-            /// keepalive-timeout: Keepalive timeout for authorized HotSpot clients. Used to detect, that the computer of the client is alive and reachable. User is logged out, when timeout value is reached
-            /// </summary>
-            [TikProperty("keepalive-timeout", UnsetOnDefault = true)]
-            public string/*time | none*/ KeepaliveTimeout { get; set; }
-
-            /// <summary>
-            /// mac-cookie-timeout: Selects mac-cookie timeout from last login or logout. Read more&gt;&gt;
-            /// </summary>
-            [TikProperty("mac-cookie-timeout", DefaultValue = "3d", UnsetOnDefault = true)]
-            public string/*time*/ MacCookieTimeout { get; set; }
-
-            /// <summary>
-            /// name: Descriptive name of the profile
-            /// </summary>
-            [TikProperty("name", IsMandatory = true)]
-            public string Name { get; set; }
-
-            /// <summary>
-            /// on-login
-            /// Script name to be executed, when user logs in to the HotSpot from the particular profile. It is possible to get username from internal user and interface variable. For example, :log info "User $user logged in!" . If hotspot is set on bridge interface, then interface variable will show bridge as actual interface unless use-ip-firewall' is set in bridge settings.
-            /// List of available variables:
-            ///  $user
-            ///  $username (alternative var name for $user)
-            ///  $address
-            ///  $mac-address
-            ///  $interface
-            /// </summary>
-            [TikProperty("on-login", DefaultValue = "")]
-            public string OnLogin { get; set; }
-
-            /// <summary>
-            /// on-logout
-            /// Script name to be executed, when user logs out from the HotSpot.It is possible to get username from internal user and interface variable. For example, :log info "User $user logged in!" . If hotspot is set on bridge interface, then interface variable will show bridge as actual interface unless use-ip-firewall is set in bridge settings.
-            /// List of available variables:
-            ///  $user
-            ///  $username (alternative var name for $user)
-            ///  $address
-            ///  $mac-address
-            ///  $interface
-            ///  $cause
-            /// </summary>
-            [TikProperty("on-logout", DefaultValue = "")]
-            public string OnLogout { get; set; }
-
-            /// <summary>
-            /// open-status-page
-            /// Option to show status page for user authenticated with mac login method. For example to show advertisement on status page (alogin.html)
-            ///  http-login - open status page only for HTTP login (includes cookie and HTTPS) 	
-            ///  always - open HTTP status page in case of mac login as well
-            /// </summary>
-            [TikProperty("open-status-page", DefaultValue = "always")]
-            public string/*always | http-login*/ OpenStatusPage { get; set; }
-
-            /// <summary>
-            /// outgoing-filter: Name of the firewall chain applied to outgoing packets from the users of this profile, jump rule is required from built-in chain (input, forward, output) to chain=hotspot
-            /// </summary>
-            [TikProperty("outgoing-filter")]
-            public string OutgoingFilter { get; set; }
-
-            /// <summary>
-            /// outgoing-packet-mark: Packet mark put on outgoing packets from every user of this profile
-            /// </summary>
-            [TikProperty("outgoing-packet-mark")]
-            public string OutgoingPacketMark { get; set; }
-
-            /// <summary>
-            /// rate-limit: Simple dynamic queue is created for user, once it logs in to the HotSpot. Rate-limitation is configured in the following form [rx-rate[/tx-rate] [rx-burst-rate[/tx-burst-rate] [rx-burst-threshold[/tx-burst-threshold] [rx-burst-time[/tx-burst-time] [priority] [rx-rate-min[/tx-rate-min]]]]. For example, to set 1M download, 512k upload for the client, rate-limit=512k/1M
-            /// </summary>
-            [TikProperty("rate-limit", DefaultValue = "")]
-            public string RateLimit { get; set; }
-
-            /// <summary>
-            /// session-timeout: Allowed session time for client.  After this time, the user is logged out unconditionally
-            /// </summary>
-            [TikProperty("session-timeout", DefaultValue = "0s")]
-            public string/*time*/ SessionTimeout { get; set; }
-
-            /// <summary>
-            /// shared-users: Allowed number of simultaneously logged in users with the same HotSpot username
-            /// </summary>
-            [TikProperty("shared-users", DefaultValue = "unlimited")]
-            public string SharedUsers { get; set; }
-
-            /// <summary>
-            /// status-autorefresh: HotSpot status page autorefresh interval
-            /// </summary>
-            [TikProperty("status-autorefresh", DefaultValue = "none")]
-            public string/*time | none*/ StatusAutorefresh { get; set; }
-
-            /// <summary>
-            /// transparent-proxy: Use transparent HTTP proxy for the authorized users of this profile
-            /// </summary>
-            [TikProperty("transparent-proxy", DefaultValue = "yes")]
-            public bool TransparentProxy { get; set; }
-
-            /// <summary>
-            /// ctor
-            /// </summary>
-            public UserProfile()
-            {
-                SharedUsers = "1";
-            }
-        }
-
-        #endregion
-
+    public class HotspotUser {
         /// <summary>
         /// .id: primary key of row
         /// </summary>
@@ -220,19 +33,19 @@ namespace tik4net.Objects.Ip.Hotspot
         /// <summary>
         /// limit-bytes-in: Maximal amount of bytes that can be received from the user. User is disconnected from HotSpot after the limit is reached.
         /// </summary>
-        [TikProperty("limit-bytes-in", DefaultValue = "0")]
+        [TikProperty("limit-bytes-in")]
         public long LimitBytesIn { get; set; }
 
         /// <summary>
         /// limit-bytes-out: Maximal amount of bytes that can be transmitted from the user. User is disconnected from HotSpot after the limit is reached.
         /// </summary>
-        [TikProperty("limit-bytes-out", DefaultValue = "0")]
+        [TikProperty("limit-bytes-out")]
         public long LimitBytesOut { get; set; }
 
         /// <summary>
         /// limit-bytes-total: (limit-bytes-in+limit-bytes-out). User is disconnected from HotSpot after the limit is reached.
         /// </summary>
-        [TikProperty("limit-bytes-total", DefaultValue = "0")]
+        [TikProperty("limit-bytes-total")]
         public long LimitBytesTotal { get; set; }
 
         /// <summary>
@@ -316,11 +129,10 @@ namespace tik4net.Objects.Ip.Hotspot
         /// <summary>
         /// ctor
         /// </summary>
-        public HotspotUser()
-        {
+        public HotspotUser() {
             Server = "all";
         }
-            
+
     }
 
 }

--- a/tik4net.objects/Ip/hotspot/HotspotUserProfile.cs
+++ b/tik4net.objects/Ip/hotspot/HotspotUserProfile.cs
@@ -1,0 +1,169 @@
+﻿namespace tik4net.Objects.Ip.Hotspot {
+    /// <summary>
+    /// ip/hotspot/user: User profile menu is used for common HotSpot client settings. Profiles are like User groups with the same set of settings, rate-limit, filter chain name, etc. 
+    /// </summary>
+    [TikEntity("ip/hotspot/user/profile")]
+    public class HotspotUserProfile {
+        /// <summary>
+        /// .id: primary key of row
+        /// </summary>
+        [TikProperty(".id", IsReadOnly = true, IsMandatory = true)]
+        public string Id { get; private set; }
+
+        /// <summary>
+        /// add-mac-cookie: Allows to add mac cookie for users. Read more&gt;&gt;
+        /// </summary>
+        [TikProperty("add-mac-cookie", DefaultValue = "yes")]
+        public bool AddMacCookie { get; set; }
+
+        /// <summary>
+        /// address-list: Name of the address list in which users IP address will be added. Useful to mark traffic per user groups for queue tree configurations.
+        /// </summary>
+        [TikProperty("address-list")]
+        public string AddressList { get; set; }
+
+        /// <summary>
+        /// address-pool: IP pool name from which the user will get IP. When user has improper network settings configuration on the computer, HotSpot server makes translation and assigns correct IP address from the pool instead of incorrect one
+        /// </summary>
+        [TikProperty("address-pool", DefaultValue = "none")]
+        public string/*string |none*/ AddressPool { get; set; }
+
+        /// <summary>
+        /// advertise: Enable forced advertisement popups. After certain interval specific web-page is being displayed for HotSpot users. Advertisement page might be blocked by browsers popup blockers.
+        /// </summary>
+        [TikProperty("advertise", DefaultValue = "no")]
+        public bool Advertise { get; set; }
+
+        /// <summary>
+        /// advertise-interval: Set of intervals between advertisement popups. After the list is done, the last value is used for all further advertisements, 10 minutes
+        /// </summary>
+        [TikProperty("advertise-interval", DefaultValue = "30m,10m")]
+        public string/*time[,time[,..]]*/ AdvertiseInterval { get; set; }
+
+        /// <summary>
+        /// advertise-timeout: How long advertisement is shown, before blocking network access for HotSpot client. Connection to Internet is not allowed, when advertisement is not shown.
+        /// </summary>
+        [TikProperty("advertise-timeout", DefaultValue = "1m")]
+        public string/*time | immediately | never*/ AdvertiseTimeout { get; set; }
+
+        /// <summary>
+        /// advertise-url: List of URLs that is show for advertisement popups. After the last URL is used, list starts from the begining.
+        /// </summary>
+        [TikProperty("advertise-url")]
+        public string/*string[,string[,..]]*/ AdvertiseUrl { get; set; }
+
+        /// <summary>
+        /// idle-timeout: Maximal period of inactivity for authorized HotSpot clients. Timer is counting, when there is no traffic coming from that client and going through the router, for example computer is switched off. User is logged out, dropped of the host list, the address used by the user is freed, when timeout is reached.
+        /// </summary>
+        [TikProperty("idle-timeout", DefaultValue = "none", UnsetOnDefault = true)]
+        public string/*time | none*/ IdleTimeout { get; set; }
+
+        /// <summary>
+        /// incoming-filter: Name of the firewall chain applied to incoming packets from the users of this profile, jump rule is required from built-in chain (input, forward, output) to chain=hotspot
+        /// </summary>
+        [TikProperty("incoming-filter")]
+        public string IncomingFilter { get; set; }
+
+        /// <summary>
+        /// incoming-packet-mark: Packet mark put on incoming packets from every user of this profile
+        /// </summary>
+        [TikProperty("incoming-packet-mark")]
+        public string IncomingPacketMark { get; set; }
+
+        /// <summary>
+        /// keepalive-timeout: Keepalive timeout for authorized HotSpot clients. Used to detect, that the computer of the client is alive and reachable. User is logged out, when timeout value is reached
+        /// </summary>
+        [TikProperty("keepalive-timeout", UnsetOnDefault = true)]
+        public string/*time | none*/ KeepaliveTimeout { get; set; }
+
+        /// <summary>
+        /// mac-cookie-timeout: Selects mac-cookie timeout from last login or logout. Read more&gt;&gt;
+        /// </summary>
+        [TikProperty("mac-cookie-timeout", DefaultValue = "3d", UnsetOnDefault = true)]
+        public string/*time*/ MacCookieTimeout { get; set; }
+
+        /// <summary>
+        /// name: Descriptive name of the profile
+        /// </summary>
+        [TikProperty("name", IsMandatory = true)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// on-login
+        /// Script name to be executed, when user logs in to the HotSpot from the particular profile. It is possible to get username from internal user and interface variable. For example, :log info "User $user logged in!" . If hotspot is set on bridge interface, then interface variable will show bridge as actual interface unless use-ip-firewall' is set in bridge settings.
+        /// List of available variables:
+        ///  $user
+        ///  $username (alternative var name for $user)
+        ///  $address
+        ///  $mac-address
+        ///  $interface
+        /// </summary>
+        [TikProperty("on-login", DefaultValue = "")]
+        public string OnLogin { get; set; }
+
+        /// <summary>
+        /// on-logout
+        /// Script name to be executed, when user logs out from the HotSpot.It is possible to get username from internal user and interface variable. For example, :log info "User $user logged in!" . If hotspot is set on bridge interface, then interface variable will show bridge as actual interface unless use-ip-firewall is set in bridge settings.
+        /// List of available variables:
+        ///  $user
+        ///  $username (alternative var name for $user)
+        ///  $address
+        ///  $mac-address
+        ///  $interface
+        ///  $cause
+        /// </summary>
+        [TikProperty("on-logout", DefaultValue = "")]
+        public string OnLogout { get; set; }
+
+        /// <summary>
+        /// open-status-page
+        /// Option to show status page for user authenticated with mac login method. For example to show advertisement on status page (alogin.html)
+        ///  http-login - open status page only for HTTP login (includes cookie and HTTPS) 	
+        ///  always - open HTTP status page in case of mac login as well
+        /// </summary>
+        [TikProperty("open-status-page", DefaultValue = "always")]
+        public string/*always | http-login*/ OpenStatusPage { get; set; }
+
+        /// <summary>
+        /// outgoing-filter: Name of the firewall chain applied to outgoing packets from the users of this profile, jump rule is required from built-in chain (input, forward, output) to chain=hotspot
+        /// </summary>
+        [TikProperty("outgoing-filter")]
+        public string OutgoingFilter { get; set; }
+
+        /// <summary>
+        /// outgoing-packet-mark: Packet mark put on outgoing packets from every user of this profile
+        /// </summary>
+        [TikProperty("outgoing-packet-mark")]
+        public string OutgoingPacketMark { get; set; }
+
+        /// <summary>
+        /// rate-limit: Simple dynamic queue is created for user, once it logs in to the HotSpot. Rate-limitation is configured in the following form [rx-rate[/tx-rate] [rx-burst-rate[/tx-burst-rate] [rx-burst-threshold[/tx-burst-threshold] [rx-burst-time[/tx-burst-time] [priority] [rx-rate-min[/tx-rate-min]]]]. For example, to set 1M download, 512k upload for the client, rate-limit=512k/1M
+        /// </summary>
+        [TikProperty("rate-limit", DefaultValue = "")]
+        public string RateLimit { get; set; }
+
+        /// <summary>
+        /// session-timeout: Allowed session time for client.  After this time, the user is logged out unconditionally
+        /// </summary>
+        [TikProperty("session-timeout", DefaultValue = "0s")]
+        public string/*time*/ SessionTimeout { get; set; }
+
+        /// <summary>
+        /// shared-users: Allowed number of simultaneously logged in users with the same HotSpot username
+        /// </summary>
+        [TikProperty("shared-users", DefaultValue = "unlimited")]
+        public string SharedUsers { get; set; }
+
+        /// <summary>
+        /// status-autorefresh: HotSpot status page autorefresh interval
+        /// </summary>
+        [TikProperty("status-autorefresh", DefaultValue = "none")]
+        public string/*time | none*/ StatusAutorefresh { get; set; }
+
+        /// <summary>
+        /// transparent-proxy: Use transparent HTTP proxy for the authorized users of this profile
+        /// </summary>
+        [TikProperty("transparent-proxy", DefaultValue = "yes")]
+        public bool TransparentProxy { get; set; }
+    }
+}

--- a/tik4net.objects/tik4net.objects.csproj
+++ b/tik4net.objects/tik4net.objects.csproj
@@ -55,6 +55,8 @@
     <Compile Include="Interface\InterfaceEthernet.cs" />
     <Compile Include="Interface\InterfaceWireless.cs" />
     <Compile Include="Ip\Firewall\FirewallConnection.cs" />
+    <Compile Include="Ip\Hotspot\HotspotActive.cs" />
+    <Compile Include="Ip\Hotspot\HotspotUserProfile.cs" />
     <Compile Include="Ip\Hotspot\HotspotUser.cs" />
     <Compile Include="Ip\IpDhcpServer.cs" />
     <Compile Include="Ipv4Address.cs" />

--- a/tik4net.tests/IpHotspotActiveTest.cs
+++ b/tik4net.tests/IpHotspotActiveTest.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using tik4net.Objects;
+using tik4net.Objects.Ip.Hotspot;
+
+namespace tik4net.tests {
+    [TestClass]
+    public class IpHotspotActiveTest : TestBase {
+        [TestMethod]
+        public void LoadAllActiveWillNotFail() {
+            Connection.LoadAll<HotspotActive>();
+        }
+    }
+}

--- a/tik4net.tests/IpHotspotUserTest.cs
+++ b/tik4net.tests/IpHotspotUserTest.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using tik4net.Objects;
+using tik4net.Objects.Ip.Hotspot;
+
+namespace tik4net.tests {
+    [TestClass]
+    public class IpHotspotUserTest : TestBase {
+        [TestMethod]
+        public void ListAllUserProfilesWillNotFail() {
+            var list = Connection.LoadAll<HotspotUserProfile>().ToList();
+        }
+
+        [TestMethod]
+        public void AddSingleUserWillNotFail() {
+            var user = new HotspotUser() {
+                Name = "TEST " + DateTime.Now.ToString(),
+                LimitUptime = "1:00:00",
+                Password = "secretpass",
+            };
+
+            Connection.Save(user);
+        }
+
+        [TestMethod]
+        public void UpdateFirstUserWillNotFail() {
+            var user = Connection.LoadAll<HotspotUser>().FirstOrDefault();
+            Assert.IsNotNull(user);
+
+            user.Disabled = true;
+            Connection.Save(user);
+        }
+
+        [TestMethod]
+        public void DeleteAllUsersWillNotFail() {
+            var users = Connection.DeleteAll<HotspotUser>();
+        }
+
+        [TestMethod]
+        public void AddUserWithProfileWillNotFail() {
+            string profileName = "TEST " + DateTime.Now.ToString();
+            var profile = new HotspotUserProfile() {
+                Name = profileName,
+            };
+            Connection.Save(profile);
+
+            var user = new HotspotUser() {
+                Name = "User for " + profileName,
+                Profile = profileName,
+                LimitUptime = "1:00:00",
+            };
+            Connection.Save(user);
+        }
+
+        [TestMethod]
+        public void DeleteAllUserProfilesWillNotFail() {
+            var list = Connection.LoadAll<HotspotUserProfile>();
+            Connection.SaveListDifferences(list.Where(l => l.Name == "default") /*list with "default" as expected => delete all others*/, list);
+        }
+    }
+}

--- a/tik4net.tests/Utilities/MTikTimeUtilTests.cs
+++ b/tik4net.tests/Utilities/MTikTimeUtilTests.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace VLife.Choreographer.Utilities.TestMethods {
+    [TestClass]
+    public class IntToTimeStringTestMethods {
+        [TestMethod]
+        public void FromTestMethod_None() {
+            Assert.AreEqual("none", MTikTimeUtil.ToMTikTime(0));
+        }
+        [TestMethod]
+        public void FromTestMethod_Second() {
+            Assert.AreEqual("10s", MTikTimeUtil.ToMTikTime(10));
+        }
+        [TestMethod]
+        public void FromTestMethod_Minute() {
+            Assert.AreEqual("1m", MTikTimeUtil.ToMTikTime(60));
+        }
+
+        [TestMethod]
+        public void FromTestMethod_Hour() {
+            Assert.AreEqual("1h", MTikTimeUtil.ToMTikTime(3600));
+        }
+        [TestMethod]
+        public void FromTestMethod_Day() {
+            Assert.AreEqual("2d", MTikTimeUtil.ToMTikTime((3600 * 24 * 2)));
+        }
+
+        [TestMethod]
+        public void FromTestMethod_Week() {
+            Assert.AreEqual("1w", MTikTimeUtil.ToMTikTime((3600 * 24 * 7)));
+        }
+
+        [TestMethod]
+        public void FromTestMethod_AllFields() {
+            Assert.AreEqual("1w3d1h2m1s", MTikTimeUtil.ToMTikTime((1 + 120 + 3600 + 3600 * 24 * 10)));
+        }
+
+        [TestMethod]
+        public void FromTestMethod_Over1Year() {
+            Assert.AreEqual("71w3d", MTikTimeUtil.ToMTikTime((3600 * 24 * 500)));
+        }
+
+
+        [TestMethod]
+        public void ToTestMethod_Second() {
+            Assert.AreEqual(10, MTikTimeUtil.FromTikTime("10s"));
+        }
+        [TestMethod]
+        public void ToTestMethod_Minute() {
+            Assert.AreEqual(60, MTikTimeUtil.FromTikTime("1m"));
+        }
+
+        [TestMethod]
+        public void ToTestMethod_Hour() {
+            Assert.AreEqual(3600, MTikTimeUtil.FromTikTime("1h"));
+        }
+        [TestMethod]
+        public void ToTestMethod_Day() {
+            Assert.AreEqual((3600 * 24 * 2), MTikTimeUtil.FromTikTime("2d"));
+        }
+
+        [TestMethod]
+        public void ToTestMethod_Week() {
+            Assert.AreEqual((3600 * 24 * 7), MTikTimeUtil.FromTikTime("1w"));
+        }
+
+        [TestMethod]
+        public void ToTestMethod_AllFields() {
+            Assert.AreEqual((1 + 120 + 3600 + 3600 * 24 * 10), MTikTimeUtil.FromTikTime("1w3d1h2m1s"));
+        }
+
+        [TestMethod]
+        public void ToTestMethod_Over1Year() {
+            Assert.AreEqual((3600 * 24 * 500), MTikTimeUtil.FromTikTime("71w3d"));
+        }
+    }
+}

--- a/tik4net.tests/tik4net.tests.csproj
+++ b/tik4net.tests/tik4net.tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>tik4net.tests</RootNamespace>
     <AssemblyName>tik4net.tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -16,6 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,12 +55,12 @@
   </Choose>
   <ItemGroup>
     <Compile Include="IpHotspotTest.cs" />
+    <Compile Include="IpHotspotUserTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="InterfaceTest.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="IpFirewallTest.cs" />
     <Compile Include="InterfaceBridgeTest.cs" />
-    <Compile Include="ApiSslTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\tik4net.objects\tik4net.objects.csproj">

--- a/tik4net.tests/tik4net.tests.csproj
+++ b/tik4net.tests/tik4net.tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>tik4net.tests</RootNamespace>
     <AssemblyName>tik4net.tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -54,13 +54,14 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <Compile Include="IpHotspotTest.cs" />
+    <Compile Include="IpHotspotActiveTest.cs" />
     <Compile Include="IpHotspotUserTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="InterfaceTest.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="IpFirewallTest.cs" />
     <Compile Include="InterfaceBridgeTest.cs" />
+    <Compile Include="Utilities\MTikTimeUtilTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\tik4net.objects\tik4net.objects.csproj">

--- a/tik4net/Utilities/MTikTimeUtil.cs
+++ b/tik4net/Utilities/MTikTimeUtil.cs
@@ -1,0 +1,73 @@
+﻿using System;
+
+namespace VLife.Choreographer.Utilities {
+    /// <summary>
+    /// Functions to convert MikroTik timespans to useable formats.
+    /// </summary>
+    public static class MTikTimeUtil {
+        /// <summary>
+        /// Convert the seconds passed in to a MikroTik time string
+        /// </summary>
+        /// <param name="seconds"></param>
+        /// <returns>A string in the format the MikroTik expects for it's timespan fields</returns>
+        public static string ToMTikTime(int? seconds) {
+            return ToMTikTime((long)seconds);
+        }
+        /// <summary>
+        /// Convert the seconds passed in to a MikroTik time string
+        /// </summary>
+        /// <param name="seconds"></param>
+        /// <returns>A string in the format the MikroTik expects for it's timespan fields</returns>
+        public static string ToMTikTime(long? seconds) {
+            if (!seconds.HasValue || seconds == 0) return "0";
+            var t = TimeSpan.FromSeconds(seconds.Value);
+            var weeks = (long)t.TotalDays / 7;
+            t -= TimeSpan.FromDays(weeks * 7);
+            return
+                (weeks != 0 ? weeks + "w" : string.Empty) +
+                (t.Days != 0 ? t.Days + "d" : string.Empty) +
+                (t.Hours != 0 ? t.Hours + "h" : string.Empty) +
+                (t.Minutes != 0 ? t.Minutes + "m" : string.Empty) +
+                (t.Seconds != 0 ? t.Seconds + "s" : string.Empty);
+        }
+
+        /// <summary>
+        /// Convert a MikroTik time string to seconds
+        /// </summary>
+        /// <param name="time">The time as specified by MikroTik</param>
+        /// <returns></returns>
+        public static int FromTikTime(string time) {
+            // Sanitise the input
+            time = time.ToLower();
+            if (time == "none" || null == time) return 0;
+            int output = 0;
+            string[] split;
+            if ((split = time.Split('w')).Length >= 2) {
+                if (split.Length != 2) throw new FormatException("Multiple week sections specified");
+                output += int.Parse(split[0]) * 604800;
+                time = split[1];
+            }
+            if ((split = time.Split('d')).Length >= 2) {
+                if (split.Length != 2) throw new FormatException("Multiple day sections specified");
+                output += int.Parse(split[0]) * 86400;
+                time = split[1];
+            }
+            if ((split = time.Split('h')).Length >= 2) {
+                if (split.Length != 2) throw new FormatException("Multiple hour sections specified");
+                output += int.Parse(split[0]) * 3600;
+                time = split[1];
+            }
+            if ((split = time.Split('m')).Length >= 2) {
+                if (split.Length != 2) throw new FormatException("Multiple minute sections specified");
+                output += int.Parse(split[0]) * 60;
+                time = split[1];
+            }
+            if ((split = time.Split('s')).Length >= 2) {
+                if (split.Length != 2) throw new FormatException("Multiple second sections specified");
+                output += int.Parse(split[0]);
+                time = split[1];
+            }
+            return output;
+        }
+    }
+}

--- a/tik4net/Utilities/MTikTimeUtil.cs
+++ b/tik4net/Utilities/MTikTimeUtil.cs
@@ -11,7 +11,7 @@ namespace VLife.Choreographer.Utilities {
         /// <param name="seconds"></param>
         /// <returns>A string in the format the MikroTik expects for it's timespan fields</returns>
         public static string ToMTikTime(int? seconds) {
-            return ToMTikTime((long)seconds);
+            return ToMTikTime((long?)seconds);
         }
         /// <summary>
         /// Convert the seconds passed in to a MikroTik time string

--- a/tik4net/tik4net.csproj
+++ b/tik4net/tik4net.csproj
@@ -74,6 +74,7 @@
     <Compile Include="TikSentenceException.cs" />
     <Compile Include="TikConnectionCommCallbackEventArgs.cs" />
     <Compile Include="TikSpecialProperties.cs" />
+    <Compile Include="Utilities\MTikTimeUtil.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/tik4net/tik4net.csproj
+++ b/tik4net/tik4net.csproj
@@ -34,27 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-    <DocumentationFile>bin\Debug\tik4net.XML</DocumentationFile>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Hi,

I've updated various data types that weren't working when I went to retrieve data.
I've added a Hotspot active object.
I've added a util to help manage MikroTik's weird time formats (perhaps this could be integrated into the models to avoid exposing the consumer to timespan strings)
And I pulled HotspotUserProfile out of the HotspotUser file. This is because it wasn't obvious to look for it there - I'd actually gone about creating a new object before realising it already exists.

I've not submitted a pull request before before so let me know if I'm doing it wrong...