### PR TITLE
Added NuGet Badge to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![NuGet](https://img.shields.io/nuget/v/tik4net.svg)](https://www.nuget.org/packages/tik4net)
+
 tik4net
 ====
 


### PR DESCRIPTION
[![NuGet](https://img.shields.io/nuget/v/tik4net.svg)](https://www.nuget.org/packages/tik4net)
Using this on another project. Looks very nice when you look at the main page of the project.

If you want the badge moved to somewhere else on the readme, I can move it. But I have only ever seen it be used at the very top.