### PR TITLE
Change DstPort from long to string to allow a list of ports

### DIFF
--- a/tik4net.objects/Ip/Firewall/FirewallNat.cs
+++ b/tik4net.objects/Ip/Firewall/FirewallNat.cs
@@ -105,7 +105,7 @@ namespace tik4net.Objects.Ip.Firewall
         /// dst-port
         /// </summary>
         [TikProperty("dst-port")]
-        public long DstPort { get; set; }
+        public string DstPort { get; set; }
 
     }
 }


### PR DESCRIPTION
Fix for this error
Value '80,443,21' for property 'DstPort(dst-port)' is not in expected format 'System.Int64'.

Documentation states 
dst-port (integer[-integer]: 0..65535; Default: ) | List of destination port numbers or port number ranges
https://wiki.mikrotik.com/wiki/Manual:IP/Firewall/NAT 