### PR TITLE
Removed ExecuteSingleRowOrDefault Throw on >1 Row

### DIFF
--- a/tik4net/Api/ApiCommand.cs
+++ b/tik4net/Api/ApiCommand.cs
@@ -370,8 +370,6 @@ namespace tik4net.Api
         {
             var sentences = ExecuteList();
             
-            if (sentences.Count() > 1)
-                throw new TikCommandAmbiguousResultException(this);
             return sentences.SingleOrDefault();
         }
 


### PR DESCRIPTION
OrDefault methods should not throw exceptions.

Partial fix for #75.
There might me more cases where this method could throw an exception, so maybe a `try { ... } catch { return null; }` would be a good idea.