### PR TITLE
Ignore sections in EnsureSingleResponse

### DIFF
--- a/tik4net/Api/ApiCommand.cs
+++ b/tik4net/Api/ApiCommand.cs
@@ -194,10 +194,10 @@ namespace tik4net.Api
 
         private ApiSentence EnsureSingleResponse(IEnumerable<ApiSentence> response)
         {
-            if (response.Count() != 1)
+            if (response.Count(x => !(x.Words.Count() == 1 && x.Words.ContainsKey(".section"))) != 1)
                 throw new TikCommandUnexpectedResponseException("Single response sentence expected.", this, response.Cast<ITikSentence>());
 
-            return response.Single();
+            return response.Last();
         }
 
         private void EnsureOneReAndDone(IEnumerable<ApiSentence> response)


### PR DESCRIPTION
Changed EnsureSingleResponse to ignore responses with only ".section" words.
Fixes #96

This fix is not all that pretty, but it works.